### PR TITLE
Implement a query param parser

### DIFF
--- a/shared-kernel-infrastructure/pom.xml
+++ b/shared-kernel-infrastructure/pom.xml
@@ -16,6 +16,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.dcsa.shared-kernel</groupId>
+			<artifactId>dcsa-shared-kernel-errors</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
 		</dependency>

--- a/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/queryparams/ComparisonType.java
+++ b/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/queryparams/ComparisonType.java
@@ -1,0 +1,12 @@
+package org.dcsa.skernel.infrastructure.http.queryparams;
+
+public enum ComparisonType {
+
+  GT,
+  GTE,
+  EQ,
+  LTE,
+  LT,
+  ;
+
+}

--- a/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/queryparams/DCSAQueryParameterParser.java
+++ b/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/queryparams/DCSAQueryParameterParser.java
@@ -1,0 +1,131 @@
+package org.dcsa.skernel.infrastructure.http.queryparams;
+
+import org.dcsa.skernel.errors.exceptions.ConcreteRequestErrorMessageException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Component
+public class DCSAQueryParameterParser {
+
+  /**
+   * Parse DCSA's "foo:gt" query parameter accepting repeated versions.
+   *
+   * Note if you only support at most once instance of the parameter, then please use
+   * {@link #parseCustomQueryParameterAtMostOnce(Map, String, Function)} instead.
+   *
+   * Example usage:
+   * <pre>{@code
+   *     @Autowired
+   *     DCSAQueryParameterParser queryParameterParser;
+   *
+   *     @GetMapping
+   *     public List<Event> getEvents(@RequestParam Map<String, String> queryParams) {
+   *         List<ParsedQueryParameter<ZonedDateTime> parsedQueryParams = queryParameterParser.parseCustomQueryParameter(
+   *           queryParams,
+   *           "eventCreatedDateTime",
+   *           ZonedDateTime::parse
+   *         );
+   *         if (!parsedQueryParams.isEmpty()) {
+   *             // Use parsedQueryParams as a part of the filter.
+   *             ...
+   *         } else {
+   *             ...
+   *         }
+   *         return ...;
+   *     }
+   * }</pre>
+   *
+   * @param allQueryParameters All query parameters (typically obtained from {@code @RequestParam Map<String, String> queryParams})
+   * @param basename The basename of the query parameter.  E.g., {@code "eventCreatedDateTime"}
+   *                 If you need to parse multiple parameters ("eventCreatedDateTime" AND "eventDateTime"),
+   *                 call this method twice with distinct base names.
+   * @param valueParser A {@link Function} that translates the String into the desired value type or throws an exception on error. E.g., {@link java.time.ZonedDateTime#parse(CharSequence)}
+   * @return A (possibly empty) list of the query parameter parsed along with its values and operators.
+   * @param <T> The desired value type.
+   * @throws ConcreteRequestErrorMessageException If the parameters are present but not valid, the error is communicated
+   *  via ConcreteRequestErrorMessageException exceptions (typically, the
+   *  {@link org.dcsa.skernel.errors.infrastructure.GlobalExceptionHandler} will provide a decent result for these).
+   */
+  public <T> List<ParsedQueryParameter<T>> parseCustomQueryParameter(Map<String, String> allQueryParameters, String basename, Function<String, T> valueParser) {
+    return allQueryParameters.entrySet().stream()
+      .filter(e -> e.getKey().equals(basename) || e.getKey().startsWith(basename + ":"))
+      .map(entry -> {
+        String fullName = entry.getKey();
+        String[] parts = fullName.split(":", 2);
+        ComparisonType comparisonType;
+        T value;
+        if (parts.length < 2) {
+          assert parts[0].equals(basename);
+          // default if not defined.
+          comparisonType = ComparisonType.EQ;
+        } else {
+          comparisonType = parseComparisonType(fullName, parts[1]);
+        }
+        try {
+          value = valueParser.apply(entry.getValue());
+        } catch (RuntimeException e) {
+          throw ConcreteRequestErrorMessageException.invalidQuery(fullName, "Invalid value for " + fullName, e);
+        }
+
+        return new ParsedQueryParameter<>(basename, comparisonType, value);
+      }).toList();
+  }
+
+  /**
+   * Parse DCSA's "foo:gt" query parameter accepting at most one version.
+   *
+   * Example usage:
+   * <pre>{@code
+   *     @Autowired
+   *     DCSAQueryParameterParser queryParameterParser;
+   *
+   *     @GetMapping
+   *     public List<Event> getEvents(@RequestParam Map<String, String> queryParams) {
+   *         Optional<ParsedQueryParameter<ZonedDateTime> parsedQueryParam = queryParameterParser.parseCustomQueryParameterAtMostOnce(
+   *           queryParams,
+   *           "eventCreatedDateTime",
+   *           ZonedDateTime::parse
+   *         );
+   *         if (parsedQueryParam.isPresent()) {
+   *             // Use parsedQueryParams as a part of the filter.
+   *             ...
+   *         } else {
+   *             ...
+   *         }
+   *         return ...;
+   *     }
+   * }</pre>
+   *
+   * @param allQueryParameters All query parameters (typically obtained from {@code @RequestParam Map<String, String> queryParams})
+   * @param basename The basename of the query parameter.  E.g., {@code "eventCreatedDateTime"}
+   *                 If you need to parse multiple parameters ("eventCreatedDateTime" AND "eventDateTime"),
+   *                 call this method twice with distinct base names.
+   * @param valueParser A {@link Function} that translates the String into the desired value type or throws an exception on error. E.g., {@link java.time.ZonedDateTime#parse(CharSequence)}
+   * @return An instance of the parsed query parameter along with its value and comparison type or {@link Optional#empty()}.
+   * @param <T> The desired value type.
+   * @throws ConcreteRequestErrorMessageException If the parameters are present but not valid, the error is communicated
+   *  via ConcreteRequestErrorMessageException exceptions (typically, the
+   *  {@link org.dcsa.skernel.errors.infrastructure.GlobalExceptionHandler} will provide a decent result for these).
+   */
+  public <T> Optional<ParsedQueryParameter<T>> parseCustomQueryParameterAtMostOnce(Map<String, String> allQueryParameters, String basename, Function<String, T> valueParser) {
+    List<ParsedQueryParameter<T>> matches = parseCustomQueryParameter(allQueryParameters, basename, valueParser);
+    if (matches.size() > 1) {
+      throw ConcreteRequestErrorMessageException.invalidQuery(basename, "The query parameter " + basename
+        + " can only be used once, but request provided it multiple times (with different attributes/operators).");
+    }
+    return matches.parallelStream().findFirst();
+  }
+
+  private ComparisonType parseComparisonType(String fullname, String comparisonTypeStr) {
+    try {
+      return ComparisonType.valueOf(comparisonTypeStr.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw ConcreteRequestErrorMessageException.invalidQuery(fullname, "Unknown attribute / operator: " + comparisonTypeStr);
+    }
+  }
+
+}

--- a/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/queryparams/ParsedQueryParameter.java
+++ b/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/queryparams/ParsedQueryParameter.java
@@ -1,0 +1,8 @@
+package org.dcsa.skernel.infrastructure.http.queryparams;
+
+public record ParsedQueryParameter<T>(
+  String queryParameterBasename,
+  ComparisonType comparisonType,
+  T value
+  ) {
+}

--- a/shared-kernel-infrastructure/src/test/java/org/dcsa/skernel/infrastructure/http/queryparams/QueryParameterParserTest.java
+++ b/shared-kernel-infrastructure/src/test/java/org/dcsa/skernel/infrastructure/http/queryparams/QueryParameterParserTest.java
@@ -1,0 +1,127 @@
+package org.dcsa.skernel.infrastructure.http.queryparams;
+
+import org.dcsa.skernel.errors.exceptions.ConcreteRequestErrorMessageException;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QueryParameterParserTest {
+
+
+  private static final String VALID_DATETIME_AS_STRING = "2021-04-01T14:12:56+01:00";
+  private static final ZonedDateTime VALID_DATETIME = ZonedDateTime.parse(VALID_DATETIME_AS_STRING);
+  private static final String QUERY_PARAM_ECDT = "eventCreatedDateTime";
+
+  private final DCSAQueryParameterParser dcsaQueryParameterParser = new DCSAQueryParameterParser();
+
+  @Test
+  public void testQueryParameterParserSimple() {
+    List<ParsedQueryParameter<ZonedDateTime>> results = dcsaQueryParameterParser.parseCustomQueryParameter(
+      Map.of(QUERY_PARAM_ECDT, VALID_DATETIME_AS_STRING),
+      QUERY_PARAM_ECDT, ZonedDateTime::parse);
+
+    assertEquals(
+      List.of(new ParsedQueryParameter<>(QUERY_PARAM_ECDT, ComparisonType.EQ, VALID_DATETIME)),
+      results
+    );
+
+    results = dcsaQueryParameterParser.parseCustomQueryParameter(
+      Map.of("RandomUnrelatedOption", VALID_DATETIME_AS_STRING),
+      QUERY_PARAM_ECDT, ZonedDateTime::parse);
+    assertEquals(Collections.emptyList(), results);
+  }
+
+
+  @Test
+  public void testQueryParameterParserSimpleAtMostOnce() {
+    Optional<ParsedQueryParameter<ZonedDateTime>> result = dcsaQueryParameterParser.parseCustomQueryParameterAtMostOnce(
+      Map.of(QUERY_PARAM_ECDT, VALID_DATETIME_AS_STRING),
+      QUERY_PARAM_ECDT, ZonedDateTime::parse);
+
+    assertEquals(
+      Optional.of(new ParsedQueryParameter<>(QUERY_PARAM_ECDT, ComparisonType.EQ, VALID_DATETIME)),
+      result
+    );
+
+    result = dcsaQueryParameterParser.parseCustomQueryParameterAtMostOnce(
+      Map.of("RandomUnrelatedOption", VALID_DATETIME_AS_STRING),
+      QUERY_PARAM_ECDT, ZonedDateTime::parse);
+    assertEquals(Optional.empty(), result);
+  }
+
+
+  @Test
+  public void testQueryParameterParserWithAttributes() {
+    for (ComparisonType comparisonType : ComparisonType.values()) {
+      Optional<ParsedQueryParameter<ZonedDateTime>> result = dcsaQueryParameterParser.parseCustomQueryParameterAtMostOnce(
+        Map.of(QUERY_PARAM_ECDT + ":" + comparisonType.name().toLowerCase(), VALID_DATETIME_AS_STRING),
+        QUERY_PARAM_ECDT, ZonedDateTime::parse);
+
+      assertEquals(
+        Optional.of(new ParsedQueryParameter<>(QUERY_PARAM_ECDT, comparisonType, VALID_DATETIME)),
+        result
+      );
+
+    }
+
+    Optional<ParsedQueryParameter<ZonedDateTime>> result = dcsaQueryParameterParser.parseCustomQueryParameterAtMostOnce(
+      Map.of("RandomUnrelatedOption:withAttribute", VALID_DATETIME_AS_STRING),
+      QUERY_PARAM_ECDT, ZonedDateTime::parse);
+    assertEquals(Optional.empty(), result);
+  }
+
+  @Test
+  public void testQueryParameterParserWithMany() {
+    List<ParsedQueryParameter<ZonedDateTime>> results = dcsaQueryParameterParser.parseCustomQueryParameter(
+      new LinkedHashMap<>(){{
+        put(QUERY_PARAM_ECDT + ":lt", VALID_DATETIME_AS_STRING);
+        put(QUERY_PARAM_ECDT + ":gt", VALID_DATETIME_AS_STRING);
+      }},
+      QUERY_PARAM_ECDT,
+      ZonedDateTime::parse
+    );
+
+    assertEquals(
+      List.of(
+        new ParsedQueryParameter<>(QUERY_PARAM_ECDT, ComparisonType.LT, VALID_DATETIME),
+        new ParsedQueryParameter<>(QUERY_PARAM_ECDT, ComparisonType.GT, VALID_DATETIME)
+      ),
+      results
+    );
+
+    ConcreteRequestErrorMessageException exception = assertThrows(
+      ConcreteRequestErrorMessageException.class,
+      () -> dcsaQueryParameterParser.parseCustomQueryParameterAtMostOnce(
+      new LinkedHashMap<>(){{
+        put(QUERY_PARAM_ECDT + ":lt", VALID_DATETIME_AS_STRING);
+        put(QUERY_PARAM_ECDT + ":gt", VALID_DATETIME_AS_STRING);
+      }},
+      QUERY_PARAM_ECDT,
+      ZonedDateTime::parse
+    ));
+    assertTrue(exception.getMessage().contains("can only be used once"));
+  }
+
+  @Test
+  public void testAssertThrows() {
+    ConcreteRequestErrorMessageException exception = assertThrows(
+      ConcreteRequestErrorMessageException.class,
+      () -> dcsaQueryParameterParser.parseCustomQueryParameter(
+        Map.of(QUERY_PARAM_ECDT + ":UNKNOWN", VALID_DATETIME_AS_STRING),
+        QUERY_PARAM_ECDT, ZonedDateTime::parse)
+    );
+    assertTrue(exception.getMessage().contains("Unknown attribute / operator"));
+
+    exception = assertThrows(
+      ConcreteRequestErrorMessageException.class,
+      () -> dcsaQueryParameterParser.parseCustomQueryParameter(
+        Map.of(QUERY_PARAM_ECDT, VALID_DATETIME_AS_STRING),
+        QUERY_PARAM_ECDT, s -> {throw new IllegalArgumentException("foo");})
+    );
+    assertTrue(exception.getMessage().contains("Invalid value"));
+  }
+
+}


### PR DESCRIPTION
To be used for parsing query parameters with attributes such as `eventCreatedDateTime:gte=2021-04-01T14:12:56+01:00`.

```java
     @Autowired
     DCSAQueryParameterParser queryParameterParser;

     @GetMapping
     public List<Event> getEvents(@RequestParam Map<String, String> queryParams) {
         Optional<ParsedQueryParameter<ZonedDateTime> parsedQueryParam = queryParameterParser.parseCustomQueryParameterAtMostOnce(
           queryParams,
           "eventCreatedDateTime",
           ZonedDateTime::parse
         );
         if (parsedQueryParam.isPresent()) {
             // Use parsedQueryParams as a part of the filter.
             ...
         } else {
             ...
         }
         return ...;
     }
```

The parsed query parameter contains the following fields:

- `queryParameterBasename`, which is the query parameter name listed in swagger. This would be the `eventCreatedDateTime` part of `eventCreatedDateTime:gte=2021-04-01T14:12:56+01:00`.
- `comparisonType` which is an enum representing the supported comparison types. This is the (optional) `:gte` part of `eventCreatedDateTime:gte=2021-04-01T14:12:56+01:00` - it defaults to `EQ` if omitted.
- `value` is the parsed value as returned by the provided parser function.