### PR TITLE
only log.warn for 5xx errors

### DIFF
--- a/shared-kernel-errors/src/main/java/org/dcsa/skernel/errors/infrastructure/ConcreteRequestErrorMessageExceptionHandler.java
+++ b/shared-kernel-errors/src/main/java/org/dcsa/skernel/errors/infrastructure/ConcreteRequestErrorMessageExceptionHandler.java
@@ -27,7 +27,7 @@ public class ConcreteRequestErrorMessageExceptionHandler extends BaseExceptionHa
     HttpStatus httpStatus =
       responseStatusAnnotation != null ? responseStatusAnnotation.value() : HttpStatus.INTERNAL_SERVER_ERROR;
 
-    if (httpStatus.isError()) {
+    if (httpStatus.is5xxServerError()) {
       log.warn("Exception {}: {}", e.getClass().getName(), e.getMessage(), e);
     } else {
       log.debug("Exception {}: {}", e.getClass().getName(), e.getMessage());


### PR DESCRIPTION
logging warn and the full stacktrace for 4xx errors is excessive