### PR TITLE
DDT-1268: Support multiple DCSA specifications per application

### DIFF
--- a/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/headers/api/version/ApiVersionHeaderFilter.java
+++ b/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/headers/api/version/ApiVersionHeaderFilter.java
@@ -1,6 +1,6 @@
 package org.dcsa.skernel.infrastructure.http.headers.api.version;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -9,15 +9,60 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static org.dcsa.skernel.infrastructure.http.headers.api.version.DcsaSpecificationConfiguration.CONTEXT_PREFIX_PATTERN;
+import static org.dcsa.skernel.infrastructure.http.headers.api.version.DcsaSpecificationConfiguration.UNOFFICIAL;
+
+@RequiredArgsConstructor
 @Component
 public class ApiVersionHeaderFilter extends OncePerRequestFilter {
-  @Value("${dcsa.specification.version:N/A}")
-  private String apiVersion;
+
+  private final DcsaSpecificationConfiguration dcsaSpecificationConfigration;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-    response.setHeader("API-Version", apiVersion);
+    String requestURI = request.getRequestURI();
+    String specVersion = null;
+    String pathPrefix = null;
+    if (requestURI.startsWith(request.getContextPath() + "/actuator")) {
+      // The actuators are unofficial APIs - we explicitly tag them as such because
+      // they do not match the DCSA version prefix (unless the context path forces
+      // them to do so), which risks rejecting requests to the health check when
+      // the "by-prefix" versioning is used.
+      specVersion = UNOFFICIAL;
+    } else if (requestURI.toLowerCase().contains("/unofficial/")) {
+      // If the path is /unofficial/, then we know it does not have a valid version
+      // and we can just shorten the process here.  This also exempts unversioned
+      // URLs from having a specification version in the "by-prefix" case making
+      // that less of a hassle.
+      specVersion = UNOFFICIAL;
+    } else {
+      Matcher m = CONTEXT_PREFIX_PATTERN.matcher(requestURI);
+      if (m.matches()) {
+        pathPrefix = m.group(1);
+        specVersion = dcsaSpecificationConfigration.getSpecificationVersion(pathPrefix);
+      }
+    }
+    if (specVersion != null) {
+      response.setHeader("API-Version", specVersion);
+    } else if (dcsaSpecificationConfigration.isRejectUnversionedContexts()) {
+      response.setStatus(404);
+      // Here to catch missing specifications, so it is sufficient as far as error goes.
+      String errorMessage = "The context path \"" + request.getRequestURI()
+        + "\" does not have a API specification version but is declared as using \"per prefix\""
+        + " DCSA specification rules."
+        + " If this path should host a DCSA compliant API, please check the configuration"
+        + " (dcsa.specification) to ensure the context is properly declared.";
+      if (pathPrefix != null) {
+        errorMessage += " The prefix to configure would be \"" + pathPrefix + "\"";
+      }
+      response.setContentType("text/plain");
+      response.setCharacterEncoding("UTF-8");
+      response.getWriter().println(errorMessage);
+      return;
+    }
     filterChain.doFilter(request, response);
   }
 }

--- a/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/headers/api/version/DcsaSpecificationConfiguration.java
+++ b/shared-kernel-infrastructure/src/main/java/org/dcsa/skernel/infrastructure/http/headers/api/version/DcsaSpecificationConfiguration.java
@@ -1,0 +1,85 @@
+package org.dcsa.skernel.infrastructure.http.headers.api.version;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+@Configuration
+@ConfigurationProperties("dcsa.specification")
+@Setter
+@Getter
+public class DcsaSpecificationConfiguration {
+
+  static final String UNOFFICIAL = "THIS-CONTEXT-PATH-IS-AN-UNOFFICIAL-API";
+  static final Pattern CONTEXT_PREFIX_PATTERN = Pattern.compile(
+    // Match with up to 5 leading contexts (to avoid a run-away regex).
+    "^((?:/+[^/\\s]+){0,5}/+v\\d+)(?:/.*)?$"
+  );
+
+  private String version;
+  // We use a list here as Spring "eats" the "/" in property keys.
+  private List<PrefixSpecificationRule> byPrefix;
+
+  private Map<String, String> byPrefixCache = Collections.emptyMap();
+
+  public void setByPrefix(List<PrefixSpecificationRule> byPrefix) {
+    this.byPrefix = byPrefix;
+    this.rebuildCache();
+  }
+
+  private void rebuildCache() {
+    if (byPrefix == null || byPrefix.isEmpty()) {
+      byPrefixCache = Collections.emptyMap();
+      return;
+    }
+    if (version != null && !version.equals("N/A")) {
+      throw new IllegalArgumentException("Invalid configuration in dcsa.specification: Cannot use both version"
+        + " and by-prefix at the same time");
+    }
+    byPrefixCache = new HashMap<>(byPrefix.size());
+    for (PrefixSpecificationRule rule : byPrefix) {
+      if (!CONTEXT_PREFIX_PATTERN.matcher(rule.prefix).matches()) {
+        throw new IllegalArgumentException("Invalid configuration in dcsa.specification.by-prefix: All prefixes"
+          + " must follow the pattern /vX or /foo/vX (only major versions allowed!).  Offending prefix was \""
+          + rule.prefix + "\"");
+      }
+      String existing = byPrefixCache.put(rule.prefix, normalizedVersion(rule.version));
+      if (existing != null) {
+        throw new IllegalArgumentException("Invalid configuration in dcsa.specification.by-prefix: Prefix \""
+          + rule.prefix + "\" was used twice!");
+      }
+    }
+  }
+
+  public boolean isRejectUnversionedContexts() {
+    return !this.byPrefixCache.isEmpty();
+  }
+
+  public String getSpecificationVersion(String dcsaPathVersionPrefix) {
+    Objects.requireNonNull(dcsaPathVersionPrefix, "dcsaPathVersionPrefix must be not null");
+    if (!byPrefixCache.isEmpty()) {
+     return byPrefixCache.get(dcsaPathVersionPrefix);
+    }
+    return normalizedVersion(version);
+  }
+
+  private static String normalizedVersion(String version) {
+    // We have used N/A historically for unofficial APIs (e.g., UI-Support).
+    // We might as well catch that and map it to UNOFFICIAL.
+    if (version == null || "N/A".equals(version)) {
+      return UNOFFICIAL;
+    }
+    return version;
+  }
+
+  @Data
+  public static class PrefixSpecificationRule {
+    String prefix;
+    String version;
+  }
+}


### PR DESCRIPTION
Support per-context path DCSA specification versions to aid the new DCSA-EDocumentation appliation that contains both eBL and BKG at the same time.

An example configuration could be:

```yaml
dcsa:
  specification:
    by-prefix:
      - prefix: /ebl/v2
        version: 2.0
      - prefix: /bkg/v1
        version: 1.0
```

In the implementation, the following aspects were evaluated:

 1. The existing `dcsa.specification.version` remains and (mostly) retains the existing behaviour.
 2. Unofficial APIs are now detected and flagged as such. Notably `/actuator` and any URI matching `/unofficial/` are automatically considered "unofficial" API.  These get a `API-Version` set to `THIS-CONTEXT-PATH-IS-AN-UNOFFICIAL-API`, which should clarify whether the context is part of the DCSA standard.
 3. When using `by-prefix` versioning, the implementation will now detect unversioned paths that are not known to be unofficial. This will trigger a 404 with a custom error message to help us spot missing entries under `by-prefix`.
 4. We support at most 5 "levels" before the version in the URI. (e.g. `/foo/v1` is one level).  The choice of having a limit was to ensure the regex to limit the amount of backtracking the regex would do in some cases (the choice of 5 was arbitrary but felt like it was "more than we will ever need").
 5. The choice using a list for `by-prefix` was because Spring kept eating the `/` parts of the keys (properties).  Otherwise, directly using a YAML object with prefixes as keys would have been better.

Signed-off-by: Niels Thykier <nt@asseco.dk>