### PR TITLE
DDT-1285: Provide correct HTTP code for "Method Not Allowed"

### DIFF
--- a/shared-kernel-errors/src/main/java/org/dcsa/skernel/errors/infrastructure/BaseExceptionHandler.java
+++ b/shared-kernel-errors/src/main/java/org/dcsa/skernel/errors/infrastructure/BaseExceptionHandler.java
@@ -4,6 +4,7 @@ import org.dcsa.skernel.errors.transferobjects.ConcreteRequestErrorMessageTO;
 import org.dcsa.skernel.errors.transferobjects.RequestFailureTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
@@ -14,8 +15,16 @@ public abstract class BaseExceptionHandler {
     return response(request, httpStatus, Arrays.asList(errors));
   }
 
+  protected ResponseEntity<RequestFailureTO> response(HttpServletRequest request, HttpStatus httpStatus, MultiValueMap<String, String> headers, ConcreteRequestErrorMessageTO... errors) {
+    return response(request, httpStatus, headers, Arrays.asList(errors));
+  }
+
   protected ResponseEntity<RequestFailureTO> response(HttpServletRequest request, HttpStatus httpStatus, List<ConcreteRequestErrorMessageTO> errors) {
+    return response(request, httpStatus, null, errors);
+  }
+
+  protected ResponseEntity<RequestFailureTO> response(HttpServletRequest request, HttpStatus httpStatus, MultiValueMap<String, String> headers, List<ConcreteRequestErrorMessageTO> errors) {
     RequestFailureTO failureTO = new RequestFailureTO(request.getMethod(), request.getRequestURI(), errors, httpStatus);
-    return new ResponseEntity<>(failureTO, httpStatus);
+    return new ResponseEntity<>(failureTO, headers, httpStatus);
   }
 }

--- a/shared-kernel-errors/src/main/java/org/dcsa/skernel/errors/infrastructure/MethodNotSupposedExceptionHandler.java
+++ b/shared-kernel-errors/src/main/java/org/dcsa/skernel/errors/infrastructure/MethodNotSupposedExceptionHandler.java
@@ -1,0 +1,37 @@
+package org.dcsa.skernel.errors.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.dcsa.skernel.errors.transferobjects.ConcreteRequestErrorMessageTO;
+import org.dcsa.skernel.errors.transferobjects.RequestFailureTO;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@Order(1)
+@RestControllerAdvice
+public class MethodNotSupposedExceptionHandler extends BaseExceptionHandler {
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<RequestFailureTO> handleException(HttpServletRequest httpServletRequest, HttpRequestMethodNotSupportedException e) {
+    MultiValueMap<String, String> headers = null;
+    String[] methods = e.getSupportedMethods();
+    if (methods != null) {
+      headers = new HttpHeaders();
+      headers.add("Allow", String.join(", ", methods));
+    }
+    return response(
+      httpServletRequest,
+      HttpStatus.METHOD_NOT_ALLOWED,
+      headers,
+      new ConcreteRequestErrorMessageTO("internalError", "Internal error")
+    );
+  }
+}


### PR DESCRIPTION
We previously rewrote it into a `500 Internal Server Error`, which was confusing and also hard to debug (unless you had access to the server log).

Signed-off-by: Niels Thykier <nt@asseco.dk>