### PR TITLE
Make the AddressMapper strict in target mapping

### DIFF
--- a/shared-kernel-infrastructure-services/src/main/java/org/dcsa/skernel/infrastructure/services/mapping/AddressMapper.java
+++ b/shared-kernel-infrastructure-services/src/main/java/org/dcsa/skernel/infrastructure/services/mapping/AddressMapper.java
@@ -3,9 +3,12 @@ package org.dcsa.skernel.infrastructure.services.mapping;
 import org.dcsa.skernel.domain.persistence.entity.Address;
 import org.dcsa.skernel.infrastructure.transferobject.AddressTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface AddressMapper {
   AddressTO toDTO(Address address);
+  @Mapping(target = "id", ignore = true)
   Address toDAO(AddressTO address);
 }


### PR DESCRIPTION
With this change, it is now a compile error if the AddressMapper cannot map an attribute in the target entity. So we have to declare `id` as explicitly not mapped.

With this, EDocumentation can do strict mapping for the majority of its own entities.